### PR TITLE
Feature/juno pipeline show prep

### DIFF
--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -41,8 +41,8 @@ class JunoPipeline(Plugin):
         """
         Run git pull and install to the target directory
         """
-
-        delivery_task = {"code": "DeliveryTemplate", "parent": None, "type": 1040}
+        # ShowPrep Task called DeliveryTemplate
+        delivery_task = {"code": "DeliveryTemplate", "parent": None, "type": 1140}
         luna_url = "http://luna:8000/"
         meta_url = f"{luna_url}/meta"
 

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -49,7 +49,7 @@ class JunoPipeline(Plugin):
         response = self.get_task(url=meta_url, task=delivery_task)
         status_code = response.status_code
         print('TESTING')
-        print(reponse.json())
+        print(response.json())
         if status_code == 200 and not response.json():
             response = self.create_task(url=meta_url, task=delivery_task)
         print(response.status_code)

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -48,8 +48,7 @@ class JunoPipeline(Plugin):
 
         response = self.get_task(url=meta_url, task=delivery_task)
         status_code = response.status_code
-        print('TESTING')
-        print(response.json())
+
         if status_code == 200 and not response.json():
             response = self.create_task(url=meta_url, task=delivery_task)
         print(response.status_code)
@@ -111,4 +110,5 @@ class JunoPipeline(Plugin):
         """
         print('CREATING TASK')
         task["metadata"] = {"TemplateType": "Delivery"}
+        print(task)
         return request("post", url, json=task)

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -107,5 +107,5 @@ class JunoPipeline(Plugin):
         """
         create a task in luna
         """
-        task['metadata'] = {'TemplateType': 'Delivery'}
+        task["metadata"] = {"TemplateType": "Delivery"}
         return request("post", url, json=task)

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -108,7 +108,7 @@ class JunoPipeline(Plugin):
         """
         create a task in luna
         """
-        print('CREATING TASK')
+        print("CREATING TASK")
         task["metadata"] = {"TemplateType": "Delivery"}
         print(task)
         return request("post", url, json=task)

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -48,6 +48,8 @@ class JunoPipeline(Plugin):
 
         response = self.get_task(url=meta_url, task=delivery_task)
         status_code = response.status_code
+        print('TESTING')
+        print(reponse.json())
         if status_code == 200 and not response.json():
             response = self.create_task(url=meta_url, task=delivery_task)
         print(response.status_code)
@@ -107,5 +109,6 @@ class JunoPipeline(Plugin):
         """
         create a task in luna
         """
+        print('CREATING TASK')
         task["metadata"] = {"TemplateType": "Delivery"}
         return request("post", url, json=task)

--- a/terra/plugin.py
+++ b/terra/plugin.py
@@ -58,7 +58,7 @@ class Plugin:
         """
         self.logger.info(f"Updating metadata: {metadata}")
         try:
-            import src.plugins.service as service
+            from src.plugins import service
 
             service.set_metadata(os.environ["INSTALL_NAME"], metadata)
 
@@ -124,7 +124,7 @@ class Plugin:
         """
         self.logger.info("No custom installer provided.")
 
-    @staticmethod
+    @pluginlib.abstractmethod
     def uninstall(self, *args, **kwargs) -> None:  # pragma: no cover
         """
         Run uninstall process

--- a/terra/workflow.py
+++ b/terra/workflow.py
@@ -58,7 +58,7 @@ class Workflow:
         """
         self.logger.info(f"Updating metadata: {metadata}")
         try:
-            import src.plugins.service as service
+            from src.plugins import service
 
             service.set_metadata(os.environ["INSTALL_NAME"], metadata)
 


### PR DESCRIPTION
Hey Des,
This was a really quick update on my end for the JunoPipeline plugin. I did run the formatter and linter as well. I'm not sure if the staticMethod update to the @pluginlib.abstractmethod was correct, but I followed what you had for the install function. StaticMethod one,  was going to be an error since it was using self.

- adjusted our DeliveryTemplate task to utilize the new ShowPrep task type.
-  Formatted
-  Ran the linter, and adjusted 1 error. I copied over the install decorator, to our uninstall function. Let me know if this should be a different decorator.
- I left 2 other linter issues, using Ruff to disable the imports not being at the top-level. It caused Ruff to go a little crazy, and start flagging a bunch of other issues it wasn't earlier.