### PR TITLE
112 setup juno pipeline plugin to install nuke and deadline

### DIFF
--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -59,7 +59,7 @@ class JunoPipeline(Plugin):
                 'destination': nuke_destination,
             }
         }
-        request.post(url=install_url, json=data)
+        request("post", install_url, json=data)
         print('Preparing To create for Juno Nuke Desktop File')
         scripts_directory = os.path.abspath(f"{__file__}/../scripts")
         if (

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -50,8 +50,8 @@ class JunoPipeline(Plugin):
         handler = plugins()
         print('Preparing Nuke 15.1v1 install')
         handler.run_plugin(
-            "Nuke Pipeline Install",
-            "Nuke Installer",
+            name="Nuke Installer",
+            plugin="Nuke Installer",
             allow_failure=False,
             destination="/apps/nuke",
             version="Nuke15.1v1",

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -65,6 +65,8 @@ class JunoPipeline(Plugin):
             version="Nuke15.1v1",
 
         )
+
+        print('Preparing To create for Juno Nuke Desktop File')
         scripts_directory = os.path.abspath(f"{__file__}/../scripts")
         if (
             run(

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -47,17 +47,19 @@ class JunoPipeline(Plugin):
             if response.status_code == 200:
                 print('ShowPrep task Created')
 
-        handler = plugins()
         print('Preparing Nuke 15.1v1 install')
         nuke_destination = "/apps/nuke"
-        handler.run_plugin(
-            name="Nuke Installer",
-            allow_failure=False,
-            destination=nuke_destination,
-            version="Nuke15.1v1",
 
-        )
-
+        install_url = 'http://terra:8000/plugins/install'
+        data = {
+            'install_name': 'Nuke Pipeline Install',
+            'plugin_name': 'Nuke Installer',
+            'fields': {
+                'version': 'Nuke15.1v1',
+                'destination': nuke_destination,
+            }
+        }
+        request.post(url=install_url, json=data)
         print('Preparing To create for Juno Nuke Desktop File')
         scripts_directory = os.path.abspath(f"{__file__}/../scripts")
         if (

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -49,10 +49,11 @@ class JunoPipeline(Plugin):
 
         handler = plugins()
         print('Preparing Nuke 15.1v1 install')
+        nuke_destination = "/apps/nuke"
         handler.run_plugin(
             name="Nuke Installer",
             allow_failure=False,
-            destination="/apps/nuke",
+            destination=nuke_destination,
             version="Nuke15.1v1",
 
         )
@@ -61,7 +62,7 @@ class JunoPipeline(Plugin):
         scripts_directory = os.path.abspath(f"{__file__}/../scripts")
         if (
             run(
-                f"bash {scripts_directory}/juno-pipeline-installer.sh Nuke15.1v1 /apps/nuke",
+                f"bash {scripts_directory}/juno-pipeline-installer.sh {nuke_destination}",
                 shell=True,
                 check=False,
             ).returncode

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -28,15 +28,7 @@ class JunoPipeline(Plugin):
         """
         Check if the target directory exists
         """
-        # if not os.path.exists("/pipe"):
-        #     raise ValueError(
-        #         "The pipeline directory does not exist. Please ensure the pipeline is mounted to /pipe."
-        #     )
-
-        # if not os.path.exists("/apps"):
-        #     raise ValueError(
-        #         "The apps directory does not exist. Please ensure the apps are mounted to /apps."
-        #     )
+        print('testing preflight')
 
     def install(self, *args, **kwargs) -> None:
         """
@@ -46,7 +38,7 @@ class JunoPipeline(Plugin):
         delivery_task = {"code": "DeliveryTemplate", "parent": None, "type": 1140}
         luna_url = "http://luna:8000/"
         meta_url = f"{luna_url}/meta"
-
+        print('testing install')
         response = self.get_task(url=meta_url, task=delivery_task)
         status_code = response.status_code
 

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -38,7 +38,7 @@ class JunoPipeline(Plugin):
         delivery_task = {"code": "DeliveryTemplate", "parent": None, "type": 1140}
         luna_url = "http://luna:8000/"
         meta_url = f"{luna_url}/meta"
-        print('testing install')
+
         response = self.get_task(url=meta_url, task=delivery_task)
         status_code = response.status_code
 

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -4,6 +4,7 @@ Juno's Pipeline Bundle
 
 # std
 import os
+from subprocess import run
 from requests import request
 
 # 3rd
@@ -51,15 +52,29 @@ class JunoPipeline(Plugin):
 
         if status_code == 200 and not response.json():
             response = self.create_task(url=meta_url, task=delivery_task)
-        print(response.status_code)
+            if response.status_code == 200:
+                print('ShowPrep task Created')
 
-        # handler = plugins()
-        # handler.run_plugin(
-        #     "plugin",
-        #     "Pixelfudger v3.2",
-        #     allow_failure=False,
-        #     destination="/pipe/nuke/external/",
-        # )
+        handler = plugins()
+        print('Preparing Nuke 15.1v1 install')
+        handler.run_plugin(
+            "Nuke Pipeline Install",
+            "Nuke Installer",
+            allow_failure=False,
+            destination="/apps/nuke",
+            version="Nuke15.1v1",
+
+        )
+        scripts_directory = os.path.abspath(f"{__file__}/../scripts")
+        if (
+            run(
+                f"bash {scripts_directory}/juno-pipeline-installer.sh Nuke15.1v1 /apps/nuke",
+                shell=True,
+                check=False,
+            ).returncode
+            != 0
+        ):
+            raise RuntimeError("Failed to install Nuke")
 
         # handler.run_plugin(
         #     "plugin",

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -52,7 +52,7 @@ class JunoPipeline(Plugin):
 
         install_url = 'http://terra:8000/plugins/install'
         data = {
-            'install_name': 'Nuke Pipeline Install',
+            'install_name': 'Nuke Pipeline 15.1v1',
             'plugin_name': 'Nuke Installer',
             'fields': {
                 'version': 'Nuke15.1v1',

--- a/plugins/juno_pipeline.py
+++ b/plugins/juno_pipeline.py
@@ -51,7 +51,6 @@ class JunoPipeline(Plugin):
         print('Preparing Nuke 15.1v1 install')
         handler.run_plugin(
             name="Nuke Installer",
-            plugin="Nuke Installer",
             allow_failure=False,
             destination="/apps/nuke",
             version="Nuke15.1v1",
@@ -69,41 +68,6 @@ class JunoPipeline(Plugin):
             != 0
         ):
             raise RuntimeError("Failed to install Nuke")
-
-        # handler.run_plugin(
-        #     "plugin",
-        #     "Kdenlive Installer",
-        #     allow_failure=False,
-        #     destination="/apps/kdenlive",
-        # )
-        #
-        # handler.run_plugin(
-        #     "plugin",
-        #     "Blender Installer",
-        #     allow_failure=False,
-        #     destination="/apps/blender",
-        #     version="4.2.0",
-        # )
-        #
-        # handler.run_plugin(
-        #     "plugin",
-        #     "PyCharm Installer",
-        #     allow_failure=False,
-        #     destination="/apps/pycharm",
-        #     version="2024.1.4",
-        # )
-        #
-        # handler.run_plugin(
-        #     "plugin", "ComfyUI Installer", allow_failure=False, destination="/apps/comfyui"
-        # )
-        #
-        # handler.run_plugin(
-        #     "plugin",
-        #     "Nuke Installer",
-        #     allow_failure=False,
-        #     destination="/apps/nuke",
-        #     version="Nuke15.1v1",
-        # )
 
     def get_task(self, url, task):
         """

--- a/plugins/polaris_essentials.py
+++ b/plugins/polaris_essentials.py
@@ -43,24 +43,26 @@ class PolarisEssentials(Plugin):
         handler = plugins()
 
         # add firefox
-        handler.run_plugin(name="Firefox Browser", allow_failure=False)
+        handler.run_plugin("plugin", "Firefox Browser", allow_failure=False)
 
         # add WPS Office
         handler.run_plugin(
-            name="Wpsoffice Installer",
+            "plugin",
+            "Wpsoffice Installer",
             allow_failure=False,
             destination="/apps/wpsoffice",
         )
 
         # add Vlc
-        handler.run_plugin(name="Vlc Installer", allow_failure=False, destination="/apps/vlc")
+        handler.run_plugin("plugin", "Vlc Installer", allow_failure=False, destination="/apps/vlc")
 
         # add TLM
-        handler.run_plugin(name="Tlm Installer", allow_failure=False, destination="/apps/tlm")
+        handler.run_plugin("plugin", "Tlm Installer", allow_failure=False, destination="/apps/tlm")
 
         # add user Templates
         handler.run_plugin(
-            name="Templates Installer",
+            "plugin",
+            "Templates Installer",
             allow_failure=False,
             destination="/apps/templates",
         )
@@ -75,7 +77,8 @@ class PolarisEssentials(Plugin):
 
         # add Sublime3
         handler.run_plugin(
-            name="Sublime3 Installer",
+            "plugin",
+            "Sublime3 Installer",
             allow_failure=False,
             destination="/apps/sublime3",
             version="3211",
@@ -83,7 +86,8 @@ class PolarisEssentials(Plugin):
 
         # add PyCharm
         handler.run_plugin(
-            name="PyCharm Installer",
+            "plugin",
+            "PyCharm Installer",
             allow_failure=False,
             destination="/apps/pycharm",
             version="2024.1.4",
@@ -91,7 +95,8 @@ class PolarisEssentials(Plugin):
 
         # add PureRef
         handler.run_plugin(
-            name="PureRef Installer",
+            "plugin",
+            "PureRef Installer",
             allow_failure=False,
             destination="/apps/pureref",
             version="2",
@@ -99,19 +104,21 @@ class PolarisEssentials(Plugin):
 
         # add obsidian
         handler.run_plugin(
-            name="Obsidian Installer",
+            "plugin",
+            "Obsidian Installer",
             allow_failure=False,
             destination="/apps/obsidian",
         )
 
         # add ocio
         handler.run_plugin(
-            name="Ocio Installer", allow_failure=False, destination="/apps/ocio"
+            "plugin", "Ocio Installer", allow_failure=False, destination="/apps/ocio"
         )
 
         # add mrv2 player
         handler.run_plugin(
-            name="Mrv2 Installer",
+            "plugin",
+            "Mrv2 Installer",
             allow_failure=False,
             destination="/apps/mrv2",
             version="Mrv2-1.2.1",
@@ -119,7 +126,7 @@ class PolarisEssentials(Plugin):
 
         # add krita
         handler.run_plugin(
-            name="Krita Installer", allow_failure=False, destination="/apps/krita"
+            "plugin", "Krita Installer", allow_failure=False, destination="/apps/krita"
         )
 
     def uninstall(self, *args, **kwargs) -> None:

--- a/plugins/polaris_essentials.py
+++ b/plugins/polaris_essentials.py
@@ -43,26 +43,24 @@ class PolarisEssentials(Plugin):
         handler = plugins()
 
         # add firefox
-        handler.run_plugin("plugin", "Firefox Browser", allow_failure=False)
+        handler.run_plugin(name="Firefox Browser", allow_failure=False)
 
         # add WPS Office
         handler.run_plugin(
-            "plugin",
-            "Wpsoffice Installer",
+            name="Wpsoffice Installer",
             allow_failure=False,
             destination="/apps/wpsoffice",
         )
 
         # add Vlc
-        handler.run_plugin("plugin", "Vlc Installer", allow_failure=False, destination="/apps/vlc")
+        handler.run_plugin(name="Vlc Installer", allow_failure=False, destination="/apps/vlc")
 
         # add TLM
-        handler.run_plugin("plugin", "Tlm Installer", allow_failure=False, destination="/apps/tlm")
+        handler.run_plugin(name="Tlm Installer", allow_failure=False, destination="/apps/tlm")
 
         # add user Templates
         handler.run_plugin(
-            "plugin",
-            "Templates Installer",
+            name="Templates Installer",
             allow_failure=False,
             destination="/apps/templates",
         )
@@ -77,8 +75,7 @@ class PolarisEssentials(Plugin):
 
         # add Sublime3
         handler.run_plugin(
-            "plugin",
-            "Sublime3 Installer",
+            name="Sublime3 Installer",
             allow_failure=False,
             destination="/apps/sublime3",
             version="3211",
@@ -86,8 +83,7 @@ class PolarisEssentials(Plugin):
 
         # add PyCharm
         handler.run_plugin(
-            "plugin",
-            "PyCharm Installer",
+            name="PyCharm Installer",
             allow_failure=False,
             destination="/apps/pycharm",
             version="2024.1.4",
@@ -95,8 +91,7 @@ class PolarisEssentials(Plugin):
 
         # add PureRef
         handler.run_plugin(
-            "plugin",
-            "PureRef Installer",
+            name="PureRef Installer",
             allow_failure=False,
             destination="/apps/pureref",
             version="2",
@@ -104,21 +99,19 @@ class PolarisEssentials(Plugin):
 
         # add obsidian
         handler.run_plugin(
-            "plugin",
-            "Obsidian Installer",
+            name="Obsidian Installer",
             allow_failure=False,
             destination="/apps/obsidian",
         )
 
         # add ocio
         handler.run_plugin(
-            "plugin", "Ocio Installer", allow_failure=False, destination="/apps/ocio"
+            name="Ocio Installer", allow_failure=False, destination="/apps/ocio"
         )
 
         # add mrv2 player
         handler.run_plugin(
-            "plugin",
-            "Mrv2 Installer",
+            name="Mrv2 Installer",
             allow_failure=False,
             destination="/apps/mrv2",
             version="Mrv2-1.2.1",
@@ -126,7 +119,7 @@ class PolarisEssentials(Plugin):
 
         # add krita
         handler.run_plugin(
-            "plugin", "Krita Installer", allow_failure=False, destination="/apps/krita"
+            name="Krita Installer", allow_failure=False, destination="/apps/krita"
         )
 
     def uninstall(self, *args, **kwargs) -> None:

--- a/plugins/scripts/create_desktop_file.py
+++ b/plugins/scripts/create_desktop_file.py
@@ -48,8 +48,10 @@ Terminal={terminal}
 Type=Application
 Categories=X-Polaris
 Icon={icon}"""
-
-    desktop_path = destination + "/" + app_name.lower() + "_" + version + ".desktop"
+    if version:
+        desktop_path = destination + "/" + app_name.lower() + "_" + version + ".desktop"
+    else:
+        desktop_path = destination + "/" + app_name.lower() + ".desktop"
     desktop_path = pathlib.Path(desktop_path).as_posix()
     with open(desktop_path, "w") as f:
         f.write(desktop_file)

--- a/plugins/scripts/create_desktop_file.py
+++ b/plugins/scripts/create_desktop_file.py
@@ -48,10 +48,7 @@ Terminal={terminal}
 Type=Application
 Categories=X-Polaris
 Icon={icon}"""
-    if version:
-        desktop_path = destination + "/" + app_name.lower() + "_" + version + ".desktop"
-    else:
-        desktop_path = destination + "/" + app_name.lower() + ".desktop"
+    desktop_path = destination + "/" + app_name.lower() + "_" + version + ".desktop"
     desktop_path = pathlib.Path(desktop_path).as_posix()
     with open(desktop_path, "w") as f:
         f.write(desktop_file)

--- a/plugins/scripts/juno-pipeline-installer.sh
+++ b/plugins/scripts/juno-pipeline-installer.sh
@@ -2,11 +2,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # app icon setup
 cd $SCRIPT_DIR
-cp "../assets/nuke.png" "$2/nuke.png"
+cp "../assets/nuke.png" "$1/nuke.png"
 echo "Adding desktop file"
 chmod +X create_desktop_file.py
-python3 create_desktop_file.py --app_name="Juno" --latest_path="juno nuke" --version="Nuke" --categories="nuke, compositing" --destination="$1" --icon="$1"/nuke.png --terminal="True"
+python3 create_desktop_file.py --app_name="Juno" --version="Nuke" --latest_path="juno nuke" --categories="nuke, compositing" --destination="$1" --icon="$1"/nuke.png --terminal="True"
 echo "Desktop file created."
 
-cat $2/*.desktop
+cat $1/*.desktop
 

--- a/plugins/scripts/juno-pipeline-installer.sh
+++ b/plugins/scripts/juno-pipeline-installer.sh
@@ -1,0 +1,12 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# app icon setup
+cd $SCRIPT_DIR
+cp "../assets/nuke.png" "$2/nuke.png"
+echo "Adding desktop file"
+chmod +X create_desktop_file.py
+python3 create_desktop_file.py --app_name="Juno Nuke" --version=$1 --latest_path="juno nuke" --categories="nuke, compositing" --destination="$2" --icon="$2"/nuke.png --terminal="True"
+echo "Desktop file created."
+
+cat $2/*.desktop
+

--- a/plugins/scripts/juno-pipeline-installer.sh
+++ b/plugins/scripts/juno-pipeline-installer.sh
@@ -5,7 +5,7 @@ cd $SCRIPT_DIR
 cp "../assets/nuke.png" "$2/nuke.png"
 echo "Adding desktop file"
 chmod +X create_desktop_file.py
-python3 create_desktop_file.py --app_name="Juno Nuke" --version=$1 --latest_path="juno nuke" --categories="nuke, compositing" --destination="$2" --icon="$2"/nuke.png --terminal="True"
+python3 create_desktop_file.py --app_name="Juno Nuke" --latest_path="juno nuke" --categories="nuke, compositing" --destination="$1" --icon="$1"/nuke.png --terminal="True"
 echo "Desktop file created."
 
 cat $2/*.desktop

--- a/plugins/scripts/juno-pipeline-installer.sh
+++ b/plugins/scripts/juno-pipeline-installer.sh
@@ -5,7 +5,7 @@ cd $SCRIPT_DIR
 cp "../assets/nuke.png" "$2/nuke.png"
 echo "Adding desktop file"
 chmod +X create_desktop_file.py
-python3 create_desktop_file.py --app_name="Juno Nuke" --latest_path="juno nuke" --categories="nuke, compositing" --destination="$1" --icon="$1"/nuke.png --terminal="True"
+python3 create_desktop_file.py --app_name="Juno" --latest_path="juno nuke" --version="Nuke" --categories="nuke, compositing" --destination="$1" --icon="$1"/nuke.png --terminal="True"
 echo "Desktop file created."
 
 cat $2/*.desktop


### PR DESCRIPTION
Updating our Juno Pipeline Installer to install Nuke, and create our Juno Nuke desktop file.

Updates:
- using requests to hit our install endpoint directly. This allows us to see the Nuke install process within hubble, and ensures our terra config is getting updated fully. the handler.run_plugin() call does do the install, but it doesn't update our terra config map. This may be related to the metadata issue we are aware of. 
