### PR TITLE
updated to cache v3 as v2 is deprecated

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
https://github.com/actions/cache/discussions/1510

our ci  had an auto fail because of a deprecation warning.